### PR TITLE
Re route form to correct insight day

### DIFF
--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -29,7 +29,7 @@ const Form = ({ entryDate, isAuthorized, data, updateEntryDate, selections, setS
     if (!isAuthorized) {
       router.push('/');
     }
-    console.log('etnr', entryDate)
+    console.log('etnr here', `${new Date(entryDate).getMonth()+1}-${new Date(entryDate).getDate()}-${new Date(entryDate).getFullYear()}`)
     const getFormData = async () => {
       setLoading(true);
       try {
@@ -68,7 +68,7 @@ const Form = ({ entryDate, isAuthorized, data, updateEntryDate, selections, setS
         date: `${new Date(entryDate).getFullYear()}-${new Date(entryDate).getMonth() + 1}-${new Date(entryDate).getDate()}`,
       });
       setError(null);
-      router.push(`${router.asPath.includes('demo') ? '/demo' : ''}/insights`);
+      router.push(`${router.asPath.includes('demo') ? '/demo' : ''}/insights/${new Date(entryDate).getMonth()+1}-${new Date(entryDate).getDate()}-${new Date(entryDate).getFullYear()}`);
     } catch (error) {
       if (error instanceof Error) setError(error);
     }


### PR DESCRIPTION
## What I did:
- fix the bug on the button on the form so that when user saves their form data, it takes them to the insights page that corresponds to that day.

## Testing Notes: 
- Still need to test

## Did this break anything?
- [x]  No
- [ ]  Yes
- [ ]  Potentially (explain)

## Type of change
- [ ]  New feature (non-breaking change which adds functionality)
- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)
- [ ]  Skip all the other stuff and briefly explain the fix.

## Checklist:
- [ ]  If this code needs to be tested, all tests are passing
- [x]  The code runs locally
- [ ]  The code is DRY. If it's not, I tried my best 
> - will refactor soon
- [x]  I reviewed my code before pushing

## Screenshots of UI
https://github.com/lauraguerra1/celestial-cycle/assets/118419729/c0c684e2-d445-4e62-8657-bd9703ad3863


## What's next?
- I will work on refactoring and testing
