### PR TITLE
Update the cron job to grab tomorrow's horoscope when it runs

### DIFF
--- a/src/components/Insights.tsx
+++ b/src/components/Insights.tsx
@@ -5,7 +5,7 @@ import Navbar from './Navbar';
 import { useRouter } from 'next/router';
 import { getCurrentLunarPhase } from '@/utils/lunar-phase';
 import CelestialLogo from './CelestialLogo';
-import { getHoroscope, getInsights } from '@/utils/apiCalls';
+import { getInsights } from '@/utils/apiCalls';
 import { Value } from 'react-calendar/dist/cjs/shared/types';
 import Image from 'next/image';
 import DatePicker from './DatePicker';

--- a/src/pages/api/horoscope.ts
+++ b/src/pages/api/horoscope.ts
@@ -1,7 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { getSupabase } from '../../utils/supabase';
 
-export default async function getHorosopes (req: NextApiRequest, res: NextApiResponse) {
+export default async function getHorosopesRoute (req: NextApiRequest, res: NextApiResponse) {
     const { date, sign } = req.query;
   
     const supabase = getSupabase(); 

--- a/src/utils/horoscope.ts
+++ b/src/utils/horoscope.ts
@@ -4,7 +4,7 @@ import { getTodaysDate } from "@/utils/utils";
 
 async function getHoroscope(sign: string) {
   const signNumber = getSignNumber(sign);
-  const hURL = `https://www.horoscope.com/us/horoscopes/general/horoscope-general-daily-today.aspx?sign=${signNumber}`;
+  const hURL = `https://www.horoscope.com/us/horoscopes/general/horoscope-general-daily-tomorrow.aspx?sign=${signNumber}`;
 
   try {
     const response = await fetch(hURL);
@@ -41,8 +41,11 @@ function getSignNumber(sign: string) {
 }
 
 export default async function processDailyHoroscopes(date = new Date()) {
+  const tomorrow = new Date(date);
+  tomorrow.setDate(date.getDate() + 1);
+  const formattedDate = getTodaysDate(tomorrow);
+  
   const supabase = getSupabase();
-  const formattedDate = getTodaysDate(date);
   const checkExisting = await supabase
     .from("horoscopes")
     .select()


### PR DESCRIPTION
## What I did:
* This updates the cron job to grab *tomorrow's* horoscope when running to prevent `no horoscope data` showing to the user if they log in before the job has run. 

## Did this break anything?
- [X]  No
- [ ]  Yes
- [ ]  Potentially (explain)

## Type of change
- [ ]  New feature (non-breaking change which adds functionality)
- [X]  Bug fix (non-breaking change which fixes an issue)
- [ ]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)
- [ ]  Skip all the other stuff and briefly explain the fix.

## Checklist:
- [ ]  If this code needs to be tested, all tests are passing
- [X]  The code runs locally
- [X]  The code is DRY. If it's not, I tried my best
- [X]  I reviewed my code before pushing

